### PR TITLE
Update WordPress export to use Aloura branding

### DIFF
--- a/putri.WordPress.2025-07-14.xml
+++ b/putri.WordPress.2025-07-14.xml
@@ -26,7 +26,7 @@
 >
 
 <channel>
-	<title>Putri</title>
+	<title>Aloura</title>
 	<link>https://aloura.me</link>
 	<description></description>
 	<pubDate>Mon, 14 Jul 2025 00:31:48 +0000</pubDate>
@@ -616,9 +616,9 @@
 		<wp:term>
 		<wp:term_id>24</wp:term_id>
 		<wp:term_taxonomy><![CDATA[vendor]]></wp:term_taxonomy>
-		<wp:term_slug><![CDATA[putri]]></wp:term_slug>
+		<wp:term_slug><![CDATA[aloura]]></wp:term_slug>
 		<wp:term_parent><![CDATA[]]></wp:term_parent>
-		<wp:term_name><![CDATA[Putri]]></wp:term_name>
+		<wp:term_name><![CDATA[Aloura]]></wp:term_name>
 		<wp:termmeta>
 			<wp:meta_key><![CDATA[feature_modal]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
@@ -1636,11 +1636,11 @@
 		</wp:postmeta>
 							</item>
 					<item>
-		<title><![CDATA[PUTRI]]></title>
-		<link>https://aloura.me/putri/</link>
+		<title><![CDATA[ALOURA]]></title>
+		<link>https://aloura.me/aloura/</link>
 		<pubDate>Tue, 25 Jun 2024 05:12:22 +0000</pubDate>
 		<dc:creator><![CDATA[devteam]]></dc:creator>
-		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/PUTRI.png</guid>
+		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/ALOURA.png</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -1651,29 +1651,29 @@
 		<wp:post_modified_gmt><![CDATA[2024-06-25 05:12:22]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[putri]]></wp:post_name>
+		<wp:post_name><![CDATA[aloura]]></wp:post_name>
 		<wp:status><![CDATA[inherit]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>0</wp:menu_order>
 		<wp:post_type><![CDATA[attachment]]></wp:post_type>
 		<wp:post_password><![CDATA[]]></wp:post_password>
 		<wp:is_sticky>0</wp:is_sticky>
-						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/PUTRI.png]]></wp:attachment_url>
+						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/ALOURA.png]]></wp:attachment_url>
 											<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attached_file]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2024/06/PUTRI.png]]></wp:meta_value>
+		<wp:meta_value><![CDATA[2024/06/ALOURA.png]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attachment_metadata]]></wp:meta_key>
-		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:17:"2024/06/PUTRI.png";s:8:"filesize";i:1502;s:5:"sizes";a:2:{s:9:"thumbnail";a:5:{s:4:"file";s:16:"PUTRI-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:658;}s:25:"ast-transparent-logo-size";a:5:{s:4:"file";s:16:"PUTRI-150x37.png";s:5:"width";i:150;s:6:"height";i:37;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:1343;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
+		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:17:"2024/06/ALOURA.png";s:8:"filesize";i:1502;s:5:"sizes";a:2:{s:9:"thumbnail";a:5:{s:4:"file";s:16:"ALOURA-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:658;}s:25:"ast-transparent-logo-size";a:5:{s:4:"file";s:16:"ALOURA-150x37.png";s:5:"width";i:150;s:6:"height";i:37;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:1343;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
 					<item>
-		<title><![CDATA[PUTRI]]></title>
-		<link>https://aloura.me/putri-2/</link>
+		<title><![CDATA[ALOURA]]></title>
+		<link>https://aloura.me/aloura-2/</link>
 		<pubDate>Tue, 25 Jun 2024 05:12:48 +0000</pubDate>
 		<dc:creator><![CDATA[devteam]]></dc:creator>
-		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/PUTRI-1.png</guid>
+		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/ALOURA-1.png</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -1684,29 +1684,29 @@
 		<wp:post_modified_gmt><![CDATA[2024-06-25 05:12:48]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[putri-2]]></wp:post_name>
+		<wp:post_name><![CDATA[aloura-2]]></wp:post_name>
 		<wp:status><![CDATA[inherit]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>0</wp:menu_order>
 		<wp:post_type><![CDATA[attachment]]></wp:post_type>
 		<wp:post_password><![CDATA[]]></wp:post_password>
 		<wp:is_sticky>0</wp:is_sticky>
-						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/PUTRI-1.png]]></wp:attachment_url>
+						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/ALOURA-1.png]]></wp:attachment_url>
 											<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attached_file]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2024/06/PUTRI-1.png]]></wp:meta_value>
+		<wp:meta_value><![CDATA[2024/06/ALOURA-1.png]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attachment_metadata]]></wp:meta_key>
-		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:19:"2024/06/PUTRI-1.png";s:8:"filesize";i:1502;s:5:"sizes";a:1:{s:9:"thumbnail";a:5:{s:4:"file";s:18:"PUTRI-1-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:919;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
+		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:19:"2024/06/ALOURA-1.png";s:8:"filesize";i:1502;s:5:"sizes";a:1:{s:9:"thumbnail";a:5:{s:4:"file";s:18:"ALOURA-1-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:919;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
 					<item>
-		<title><![CDATA[PUTRI (1)]]></title>
-		<link>https://aloura.me/putri-1/</link>
+		<title><![CDATA[ALOURA (1)]]></title>
+		<link>https://aloura.me/aloura-1/</link>
 		<pubDate>Tue, 25 Jun 2024 06:39:53 +0000</pubDate>
 		<dc:creator><![CDATA[devteam]]></dc:creator>
-		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/PUTRI-1-1.png</guid>
+		<guid isPermaLink="false">https://aloura.me/wp-content/uploads/2024/06/ALOURA-1-1.png</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -1717,21 +1717,21 @@
 		<wp:post_modified_gmt><![CDATA[2024-06-25 06:39:53]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[putri-1]]></wp:post_name>
+		<wp:post_name><![CDATA[aloura-1]]></wp:post_name>
 		<wp:status><![CDATA[inherit]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>0</wp:menu_order>
 		<wp:post_type><![CDATA[attachment]]></wp:post_type>
 		<wp:post_password><![CDATA[]]></wp:post_password>
 		<wp:is_sticky>0</wp:is_sticky>
-						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/PUTRI-1-1.png]]></wp:attachment_url>
+						<wp:attachment_url><![CDATA[https://aloura.me/wp-content/uploads/2024/06/ALOURA-1-1.png]]></wp:attachment_url>
 											<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attached_file]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2024/06/PUTRI-1-1.png]]></wp:meta_value>
+		<wp:meta_value><![CDATA[2024/06/ALOURA-1-1.png]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attachment_metadata]]></wp:meta_key>
-		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:21:"2024/06/PUTRI-1-1.png";s:8:"filesize";i:1600;s:5:"sizes";a:1:{s:9:"thumbnail";a:5:{s:4:"file";s:20:"PUTRI-1-1-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:976;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
+		<wp:meta_value><![CDATA[a:6:{s:5:"width";i:242;s:6:"height";i:60;s:4:"file";s:21:"2024/06/ALOURA-1-1.png";s:8:"filesize";i:1600;s:5:"sizes";a:1:{s:9:"thumbnail";a:5:{s:4:"file";s:20:"ALOURA-1-1-150x60.png";s:5:"width";i:150;s:6:"height";i:60;s:9:"mime-type";s:9:"image/png";s:8:"filesize";i:976;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
 					<item>
@@ -4792,7 +4792,7 @@
 		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-		<wp:meta_value><![CDATA[https://putri-chat.hupp.in/]]></wp:meta_value>
+		<wp:meta_value><![CDATA[https://aloura-chat.hupp.in/]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
 					<item>
@@ -5239,7 +5239,7 @@ EFFECTIVE DATE 2018.1.31]]></content:encoded>
 
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
-<li>Email : <a href="mail: support@putri.com">support [@] putri.com</a></li>
+<li>Email : <a href="mail: support@aloura.com">support [@] aloura.com</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->


### PR DESCRIPTION
## Summary
- rename all references from "Putri" to "Aloura"
- update menu URL and support email

## Testing
- `grep -n "Putri" putri.WordPress.2025-07-14.xml`

------
https://chatgpt.com/codex/tasks/task_e_68745123f9bc8326bfa293c47c79a801