### PR TITLE
Implement basic paywall and messaging endpoints

### DIFF
--- a/wp-content/themes/astra-child/assets/js/modern.js
+++ b/wp-content/themes/astra-child/assets/js/modern.js
@@ -1,0 +1,27 @@
+// Vanilla JS for loading posts
+(function(){
+  var button = document.getElementById('more_posts');
+  if(!button){return;}
+  var page = 0;
+  var ppp = 6;
+  button.addEventListener('click', function(){
+    if(button.classList.contains('disabled')){return;}
+    page++;
+    var type = button.getAttribute('data-type');
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', ajax_admin.ajax_url, true);
+    xhr.setRequestHeader('Content-Type','application/x-www-form-urlencoded; charset=UTF-8');
+    xhr.onload = function(){
+      if(xhr.status === 200){
+        var div = document.createElement('div');
+        div.innerHTML = xhr.responseText;
+        if(div.children.length){
+          document.getElementById('ajax-posts').appendChild(div);
+        }else{
+          button.classList.add('disabled');
+        }
+      }
+    };
+    xhr.send('action=more_post_ajax&pageNumber='+page+'&ppp='+ppp+'&type='+type);
+  });
+})();

--- a/wp-content/themes/astra-child/inc/film-video.php
+++ b/wp-content/themes/astra-child/inc/film-video.php
@@ -67,3 +67,21 @@ function save_film_video_meta_box($post_id) {
     }
 }
 add_action('save_post', 'save_film_video_meta_box');
+
+/**
+ * Validate uploaded video files.
+ */
+function am_limit_video_upload($file) {
+    $type = wp_check_filetype($file['name']);
+    $allowed = array('mp4', 'mov', 'avi');
+    if (!in_array($type['ext'], $allowed)) {
+        $file['error'] = 'Invalid video type';
+        return $file;
+    }
+    $max = 100 * 1024 * 1024; // 100MB
+    if ($file['size'] > $max) {
+        $file['error'] = 'Video exceeds maximum size of 100MB';
+    }
+    return $file;
+}
+add_filter('wp_handle_upload_prefilter', 'am_limit_video_upload');

--- a/wp-content/themes/astra-child/single-daily-feed.php
+++ b/wp-content/themes/astra-child/single-daily-feed.php
@@ -17,9 +17,13 @@
                 <section class="section-feed-video">
                     <?php $video_url = get_post_meta(get_the_ID(), 'feed_video', true); ?>
                     <?php if ($video_url) { ?>
-                        <video controls style="width: 100%;">
-                            <source src="<?php echo $video_url; ?>" type="video/mp4">
-                        </video>
+                        <?php if (function_exists('am_is_user_subscribed') && am_is_user_subscribed()) : ?>
+                            <video controls style="width: 100%;">
+                                <source src="<?php echo $video_url; ?>" type="video/mp4">
+                            </video>
+                        <?php else : ?>
+                            <p><a href="<?php echo esc_url(home_url('/signup/')); ?>">Subscribe to unlock video</a></p>
+                        <?php endif; ?>
                     <?php } ?>
                 </section>
 

--- a/wp-content/themes/astra-child/single-film.php
+++ b/wp-content/themes/astra-child/single-film.php
@@ -18,17 +18,20 @@
                 <div class="singlepage_content_wrap">
                     <!-- Film Video -->
                     <section class="section-film-video">
-                        <?php $video_url = get_post_meta(get_the_ID(), 'model_film_video', true); ?>
-                        <?php if ($video_url) { ?>
-                            <div class="video_wrap">
-                                <p class="page_preview">Preview</p>
+                    <?php $video_url = get_post_meta(get_the_ID(), 'model_film_video', true); ?>
+                    <?php if ($video_url) { ?>
+                        <div class="video_wrap">
+                            <?php if (function_exists('am_is_user_subscribed') && am_is_user_subscribed()) : ?>
                                 <div class="video-container">
                                     <video class="preview_video" controls>
                                         <source src="<?php echo $video_url; ?>" type="video/mp4">
                                     </video>
                                 </div>
-                            </div>
-                        <?php } ?>
+                            <?php else : ?>
+                                <p><a href="<?php echo esc_url(home_url('/signup/')); ?>">Subscribe to unlock full video</a></p>
+                            <?php endif; ?>
+                        </div>
+                    <?php } ?>
 
                         <div class="film-video-content">
                             <?php the_content(); ?>


### PR DESCRIPTION
## Summary
- add helper functions to track subscriptions
- rate limit login attempts
- restrict video playback to subscribed users
- validate uploaded video files
- create REST endpoints and CPT for messaging, tipping and analytics
- add vanilla JS alternative for post loading

## Testing
- `php -l wp-content/themes/astra-child/functions.php`
- `php -l wp-content/themes/astra-child/inc/film-video.php`
- `php -l wp-content/themes/astra-child/single-film.php`
- `php -l wp-content/themes/astra-child/single-daily-feed.php`

------
https://chatgpt.com/codex/tasks/task_e_687bf314192083269f06bd16be388b67