### PR TITLE
Add performer application page template

### DIFF
--- a/wp-content/themes/astra-child/assets/css/styles.css
+++ b/wp-content/themes/astra-child/assets/css/styles.css
@@ -3546,3 +3546,32 @@ input::placeholder {
 .chat_button {
   display: none !important;
 }
+
+/*************************** performer application ********************************/
+.page-template-page-performer-application {
+  /* basic layout overrides if needed */
+}
+
+.page-template-page-performer-application .performer_application_form {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-template-page-performer-application .wpcf7-form-control-wrap input,
+.page-template-page-performer-application .wpcf7-form-control-wrap textarea {
+  background-color: #E9E9E9;
+  border: 0 !important;
+  border-radius: 0;
+  min-height: 50px;
+}
+
+.page-template-page-performer-application .wpcf7-form-control-wrap textarea {
+  height: 130px;
+}
+
+.page-template-page-performer-application .wpcf7-submit {
+  border-radius: 0 !important;
+  text-transform: uppercase;
+  font-size: 18px;
+  line-height: 30px;
+}

--- a/wp-content/themes/astra-child/page-performer-application.php
+++ b/wp-content/themes/astra-child/page-performer-application.php
@@ -1,0 +1,22 @@
+<?php
+/*
+Template Name: Performer Application
+*/
+
+/*
+ * This template displays the "Performer Application" form created
+ * with Contact Form 7. Update the form ID to match the actual
+ * form created in the WordPress admin. The plugin will handle
+ * emailing submissions to site administrators and storing them
+ * safely in the database.
+ */
+
+get_header(); ?>
+
+<main id="main" class="site-main performer-application">
+    <div class="performer_application_form">
+        <?php echo do_shortcode('[contact-form-7 id="1234" title="Performer Application"]'); ?>
+    </div>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add `page-performer-application.php` for Contact Form 7 shortcode
- style the performer application form in `styles.css`

## Testing
- `php -l wp-content/themes/astra-child/page-performer-application.php`
- `find wp-content/themes/astra-child -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687bfa67cae88326bb5001668e6b717a