### PR TITLE
Add creator application link in footer

### DIFF
--- a/wp-content/themes/astra-child/functions.php
+++ b/wp-content/themes/astra-child/functions.php
@@ -862,3 +862,11 @@ function am_record_view() {
 }
 add_action('wp_head', 'am_record_view');
 
+/**
+ * Output link to performer application in the footer.
+ */
+function astra_child_creator_footer_link() {
+    echo '<a href="' . esc_url( home_url( '/performer-application/' ) ) . '" class="apply-as-creator-link">Apply as a Creator</a>';
+}
+add_action( 'astra_footer_content_bottom', 'astra_child_creator_footer_link' );
+

--- a/wp-content/themes/astra-child/style.css
+++ b/wp-content/themes/astra-child/style.css
@@ -9,3 +9,11 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: astra-child
 Template: astra
 */
+.apply-as-creator-link {
+    display: block;
+    text-align: center;
+    margin-top: 1em;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+


### PR DESCRIPTION
## Summary
- hook into `astra_footer_content_bottom` to show a link to the performer application page
- style the link in the child theme

## Testing
- `php -l wp-content/themes/astra-child/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_687bfe7ea758832687faad9a7d0cdaba