### PR TITLE
Add OnlyFans-like chat features plugin

### DIFF
--- a/wp-content/plugins/onlyfans-like-chat/README.md
+++ b/wp-content/plugins/onlyfans-like-chat/README.md
@@ -1,0 +1,3 @@
+# OnlyFans-like Chat Features
+
+This plugin introduces basic scaffolding to add monetization features to a chat application within WordPress. It creates a database table for managing user subscriptions and registers a private post type for exclusive messages. The plugin is a starting point for building functionality such as subscription tiers, pay-per-message, and tipping.

--- a/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
+++ b/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
@@ -1,0 +1,53 @@
+<?php
+/*
+Plugin Name: OnlyFans-like Chat Features
+Description: Adds subscription tiers, pay-per-message, and tipping features for chat.
+Version: 0.1.0
+Author: ChatGPT
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+class OnlyFansLikeChat {
+    public function __construct() {
+        register_activation_hook(__FILE__, array($this, 'activate'));
+        register_deactivation_hook(__FILE__, array($this, 'deactivate'));
+        add_action('init', array($this, 'register_post_types'));
+    }
+
+    public function activate() {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $table_name = $wpdb->prefix . 'ofl_subscriptions';
+        $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            user_id bigint(20) unsigned NOT NULL,
+            tier varchar(191) NOT NULL,
+            start_date datetime NOT NULL,
+            end_date datetime DEFAULT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        dbDelta($sql);
+    }
+
+    public function deactivate() {
+        // Cleanup tasks can be placed here
+    }
+
+    public function register_post_types() {
+        register_post_type('exclusive_message', array(
+            'labels' => array(
+                'name' => __('Exclusive Messages', 'ofl'),
+                'singular_name' => __('Exclusive Message', 'ofl'),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array('title', 'editor', 'author'),
+        ));
+    }
+}
+
+new OnlyFansLikeChat();


### PR DESCRIPTION
## Summary
- create `onlyfans-like-chat` WordPress plugin
- scaffold subscription management table and post type

## Testing
- `php -l wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php`

------
https://chatgpt.com/codex/tasks/task_e_687c00eefa748326bb33d930f3917c51