### PR TITLE
Add FastAPI chat agent manager

### DIFF
--- a/chat-agent-manager/.gitignore
+++ b/chat-agent-manager/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+data/

--- a/chat-agent-manager/README.md
+++ b/chat-agent-manager/README.md
@@ -1,0 +1,35 @@
+# Chat Agent Manager
+
+This service exposes a simple FastAPI application that connects to a local [Ollama](https://ollama.ai/) LLM instance. It stores recent conversation history in SQLite and long‑term facts in a Chroma vector database.
+
+## Requirements
+
+- Python 3.10+
+- Local Ollama server running (usually listening at `http://localhost:11434`)
+- GPU drivers configured for Ollama models
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the API with:
+
+```bash
+uvicorn main:app --reload
+```
+
+Set `OLLAMA_MODEL` to override the model name (defaults to `llama2`).
+
+The main endpoint accepts a JSON payload with a `message` and `creator_id`:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/message \
+     -H 'Content-Type: application/json' \
+     -d '{"creator_id": "user1", "message": "Hello"}'
+```
+
+It returns the AI response after retrieving recent conversation history and user facts stored in Chroma.

--- a/chat-agent-manager/main.py
+++ b/chat-agent-manager/main.py
@@ -1,0 +1,119 @@
+import os
+import sqlite3
+from uuid import uuid4
+from fastapi import FastAPI
+from pydantic import BaseModel
+import httpx
+import chromadb
+from chromadb.config import Settings
+
+DB_DIR = os.path.join(os.path.dirname(__file__), 'data')
+DB_PATH = os.path.join(DB_DIR, 'chat.db')
+CHROMA_DIR = os.path.join(DB_DIR, 'chroma')
+
+app = FastAPI(title="Chat Agent Manager")
+
+# Initialize database and chroma on startup
+@app.on_event("startup")
+async def startup_event():
+    os.makedirs(DB_DIR, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            creator_id TEXT,
+            role TEXT,
+            message TEXT,
+            ts DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    os.makedirs(CHROMA_DIR, exist_ok=True)
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def get_collection():
+    client = chromadb.Client(
+        Settings(chroma_db_impl="duckdb+parquet", persist_directory=CHROMA_DIR)
+    )
+    return client.get_or_create_collection("user_facts")
+
+
+class MessageRequest(BaseModel):
+    creator_id: str
+    message: str
+
+
+@app.post("/api/v1/message")
+async def handle_message(req: MessageRequest):
+    # store user message
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO history (creator_id, role, message) VALUES (?,?,?)",
+        (req.creator_id, "user", req.message),
+    )
+    conn.commit()
+
+    # add to vector store
+    collection = get_collection()
+    collection.add_texts(
+        [req.message],
+        ids=[str(uuid4())],
+        metadatas=[{"creator_id": req.creator_id}],
+    )
+    collection.persist()
+
+    # fetch recent history
+    rows = conn.execute(
+        "SELECT role, message FROM history WHERE creator_id=? ORDER BY id DESC LIMIT 5",
+        (req.creator_id,),
+    ).fetchall()
+    history = "\n".join(
+        f"{row['role']}: {row['message']}" for row in reversed(rows)
+    )
+    conn.close()
+
+    # fetch user facts
+    results = collection.query(
+        query_texts=[req.message], n_results=3, where={"creator_id": req.creator_id}
+    )
+    facts = ""
+    if results.get("documents"):
+        docs = results["documents"][0]
+        if docs:
+            facts = "\n".join(docs)
+
+    prompt = (
+        f"User facts:\n{facts}\n"
+        f"Conversation history:\n{history}\n"
+        f"User: {req.message}\nAssistant:"
+    )
+
+    model = os.getenv("OLLAMA_MODEL", "llama2")
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            "http://localhost:11434/api/generate",
+            json={"model": model, "prompt": prompt},
+        )
+        r.raise_for_status()
+        data = r.json()
+        response_text = data.get("response", "")
+
+    # store assistant response
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO history (creator_id, role, message) VALUES (?,?,?)",
+        (req.creator_id, "assistant", response_text),
+    )
+    conn.commit()
+    conn.close()
+
+    return {"response": response_text}

--- a/chat-agent-manager/requirements.txt
+++ b/chat-agent-manager/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+chromadb


### PR DESCRIPTION
## Summary
- add new Chat Agent Manager FastAPI service
- connect to local Ollama API
- store chat history in SQLite and user facts in Chroma
- document how to run the service

## Testing
- `pip install -r chat-agent-manager/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815c6d390c8326808a300ed657cc62