### PR TITLE
Add AI chat endpoints and settings

### DIFF
--- a/wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php
+++ b/wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php
@@ -1,0 +1,76 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+class OFL_AI_Chat_Endpoints {
+    public static function register_routes() {
+        register_rest_route('ofl-chat/v1', '/send', array(
+            'methods' => 'POST',
+            'callback' => array(__CLASS__, 'handle_send'),
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ));
+    }
+
+    public static function handle_send(WP_REST_Request $request) {
+        $message   = sanitize_text_field($request->get_param('message'));
+        $creator_id = sanitize_text_field($request->get_param('creator_id'));
+
+        if (empty($message) || empty($creator_id)) {
+            return new WP_Error('missing_params', 'creator_id and message are required', array('status' => 400));
+        }
+
+        $api_url = rtrim(get_option('ofl_chat_api_url'), '/');
+        if (!$api_url) {
+            return new WP_Error('no_api_url', 'API URL not configured', array('status' => 500));
+        }
+        $api_key = get_option('ofl_chat_api_key');
+
+        $body = wp_json_encode(array(
+            'creator_id' => $creator_id,
+            'message'    => $message,
+        ));
+        $args = array(
+            'headers' => array(
+                'Content-Type' => 'application/json',
+            ),
+            'body'    => $body,
+            'timeout' => 20,
+        );
+        if (!empty($api_key)) {
+            $args['headers']['Authorization'] = 'Bearer ' . $api_key;
+        }
+
+        $response = wp_remote_post($api_url, $args);
+        if (is_wp_error($response)) {
+            return new WP_Error('api_error', $response->get_error_message(), array('status' => 500));
+        }
+        $code = wp_remote_retrieve_response_code($response);
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+        $reply = $data['response'] ?? '';
+
+        if ($code >= 300 || !$reply) {
+            return new WP_Error('api_error', 'Invalid response from AI service', array('status' => 500));
+        }
+
+        $post_id = wp_insert_post(array(
+            'post_type'   => 'private_message',
+            'post_title'  => 'AI Reply to ' . $creator_id,
+            'post_content'=> $reply,
+            'post_status' => 'publish',
+            'post_author' => get_current_user_id(),
+            'meta_input'  => array(
+                'recipient'        => $creator_id,
+                'original_message' => $message,
+            ),
+        ));
+
+        return array(
+            'id'       => $post_id,
+            'response' => $reply,
+        );
+    }
+}

--- a/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
+++ b/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
@@ -15,6 +15,9 @@ class OnlyFansLikeChat {
         register_activation_hook(__FILE__, array($this, 'activate'));
         register_deactivation_hook(__FILE__, array($this, 'deactivate'));
         add_action('init', array($this, 'register_post_types'));
+        add_action('admin_menu', array($this, 'register_settings_page'));
+        add_action('admin_init', array($this, 'register_settings'));
+        add_action('rest_api_init', array($this, 'load_rest_endpoints'));
     }
 
     public function activate() {
@@ -47,6 +50,58 @@ class OnlyFansLikeChat {
             'show_ui' => true,
             'supports' => array('title', 'editor', 'author'),
         ));
+    }
+
+    public function load_rest_endpoints() {
+        require_once plugin_dir_path(__FILE__) . 'class-ai-chat-endpoints.php';
+        OFL_AI_Chat_Endpoints::register_routes();
+    }
+
+    public function register_settings_page() {
+        add_options_page(
+            'OnlyFans-like Chat',
+            'OnlyFans-like Chat',
+            'manage_options',
+            'onlyfans-like-chat',
+            array($this, 'settings_page_html')
+        );
+    }
+
+    public function register_settings() {
+        register_setting('ofl_chat_settings', 'ofl_chat_api_url');
+        register_setting('ofl_chat_settings', 'ofl_chat_api_key');
+    }
+
+    public function settings_page_html() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('OnlyFans-like Chat Settings', 'ofl'); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields('ofl_chat_settings');
+                ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row">
+                            <label for="ofl_chat_api_url"><?php esc_html_e('API URL', 'ofl'); ?></label>
+                        </th>
+                        <td>
+                            <input name="ofl_chat_api_url" type="text" id="ofl_chat_api_url" value="<?php echo esc_attr(get_option('ofl_chat_api_url')); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="ofl_chat_api_key"><?php esc_html_e('API Key', 'ofl'); ?></label>
+                        </th>
+                        <td>
+                            <input name="ofl_chat_api_key" type="text" id="ofl_chat_api_key" value="<?php echo esc_attr(get_option('ofl_chat_api_key')); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
     }
 }
 


### PR DESCRIPTION
## Summary
- register new REST endpoint for AI chat replies
- store AI replies as `private_message` posts
- add plugin settings for API URL and key
- load AI chat endpoints when REST API initializes

## Testing
- `php -l wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php`
- `php -l wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php`


------
https://chatgpt.com/codex/tasks/task_e_688160871b188326988664e301c80167