### PR TITLE
Add memory summaries and user spend tracking

### DIFF
--- a/chat-agent-manager/main.py
+++ b/chat-agent-manager/main.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import json
 from uuid import uuid4
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -29,6 +30,15 @@ async def startup_event():
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_traits (
+            creator_id TEXT PRIMARY KEY,
+            traits TEXT,
+            last_summary_ts DATETIME
+        )
+        """
+    )
     conn.commit()
     conn.close()
     os.makedirs(CHROMA_DIR, exist_ok=True)
@@ -47,9 +57,44 @@ def get_collection():
     return client.get_or_create_collection("user_facts")
 
 
+async def summarise_old_messages(creator_id: str, conn, collection):
+    rows = conn.execute(
+        "SELECT id, role, message FROM history WHERE creator_id=? ORDER BY id",
+        (creator_id,),
+    ).fetchall()
+    if len(rows) <= 20:
+        return
+    to_sum = rows[:-10]
+    text = "\n".join(f"{r['role']}: {r['message']}" for r in to_sum)
+    model = os.getenv("OLLAMA_MODEL", "llama2")
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            "http://localhost:11434/api/generate",
+            json={
+                "model": model,
+                "prompt": f"Summarise the following conversation highlighting favourite topics:\n{text}\nSummary:",
+            },
+        )
+        r.raise_for_status()
+        summary = r.json().get("response", "")
+    if summary:
+        collection.add_texts(
+            [summary],
+            ids=[str(uuid4())],
+            metadatas=[{"creator_id": creator_id, "type": "summary"}],
+        )
+        collection.persist()
+        last_id = to_sum[-1]["id"]
+        conn.execute(
+            "DELETE FROM history WHERE creator_id=? AND id<=?", (creator_id, last_id)
+        )
+        conn.commit()
+
+
 class MessageRequest(BaseModel):
     creator_id: str
     message: str
+    traits: dict | None = None
 
 
 @app.post("/api/v1/message")
@@ -61,6 +106,24 @@ async def handle_message(req: MessageRequest):
         (req.creator_id, "user", req.message),
     )
     conn.commit()
+
+    if req.traits:
+        row = conn.execute(
+            "SELECT traits FROM user_traits WHERE creator_id=?",
+            (req.creator_id,),
+        ).fetchone()
+        data = {}
+        if row and row[0]:
+            try:
+                data = json.loads(row[0])
+            except Exception:
+                data = {}
+        data.update(req.traits)
+        conn.execute(
+            "INSERT OR REPLACE INTO user_traits (creator_id, traits, last_summary_ts) VALUES (?, ?, COALESCE((SELECT last_summary_ts FROM user_traits WHERE creator_id=?), CURRENT_TIMESTAMP))",
+            (req.creator_id, json.dumps(data), req.creator_id),
+        )
+        conn.commit()
 
     # add to vector store
     collection = get_collection()
@@ -83,7 +146,7 @@ async def handle_message(req: MessageRequest):
 
     # fetch user facts
     results = collection.query(
-        query_texts=[req.message], n_results=3, where={"creator_id": req.creator_id}
+        query_texts=[req.message], n_results=5, where={"creator_id": req.creator_id}
     )
     facts = ""
     if results.get("documents"):
@@ -91,7 +154,15 @@ async def handle_message(req: MessageRequest):
         if docs:
             facts = "\n".join(docs)
 
+    conn = get_db()
+    row = conn.execute(
+        "SELECT traits FROM user_traits WHERE creator_id=?", (req.creator_id,)
+    ).fetchone()
+    traits_txt = row[0] if row and row[0] else ""
+    conn.close()
+
     prompt = (
+        f"Segmentation tags:\n{traits_txt}\n"
         f"User facts:\n{facts}\n"
         f"Conversation history:\n{history}\n"
         f"User: {req.message}\nAssistant:"
@@ -114,6 +185,7 @@ async def handle_message(req: MessageRequest):
         (req.creator_id, "assistant", response_text),
     )
     conn.commit()
+    await summarise_old_messages(req.creator_id, conn, collection)
     conn.close()
 
     return {"response": response_text}

--- a/wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php
+++ b/wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php
@@ -28,9 +28,20 @@ class OFL_AI_Chat_Endpoints {
         }
         $api_key = get_option('ofl_chat_api_key');
 
+        $user_id = get_current_user_id();
+        $spend   = (float) get_user_meta($user_id, 'ofl_total_spend', true);
+        $spend  += 1; // simple per-message cost
+        update_user_meta($user_id, 'ofl_total_spend', $spend);
+        $last = current_time('mysql');
+        update_user_meta($user_id, 'ofl_last_ai_chat', $last);
+
         $body = wp_json_encode(array(
             'creator_id' => $creator_id,
             'message'    => $message,
+            'traits'     => array(
+                'total_spend'     => $spend,
+                'last_interaction'=> $last,
+            ),
         ));
         $args = array(
             'headers' => array(

--- a/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
+++ b/wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php
@@ -65,6 +65,14 @@ class OnlyFansLikeChat {
             'onlyfans-like-chat',
             array($this, 'settings_page_html')
         );
+        add_submenu_page(
+            'options-general.php',
+            'High Value Fans',
+            'High Value Fans',
+            'manage_options',
+            'ofl-high-value-fans',
+            array($this, 'high_value_fans_page_html')
+        );
     }
 
     public function register_settings() {
@@ -100,6 +108,38 @@ class OnlyFansLikeChat {
                 </table>
                 <?php submit_button(); ?>
             </form>
+        </div>
+        <?php
+    }
+
+    public function high_value_fans_page_html() {
+        $users = get_users(array(
+            'meta_key' => 'ofl_total_spend',
+            'orderby'  => 'meta_value_num',
+            'order'    => 'DESC',
+            'number'   => 50,
+        ));
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('High Value Fans', 'ofl'); ?></h1>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e('User', 'ofl'); ?></th>
+                        <th><?php esc_html_e('Total Spend', 'ofl'); ?></th>
+                        <th><?php esc_html_e('Last AI Chat', 'ofl'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($users as $u) : ?>
+                    <tr>
+                        <td><?php echo esc_html($u->user_login); ?></td>
+                        <td><?php echo esc_html(get_user_meta($u->ID, 'ofl_total_spend', true)); ?></td>
+                        <td><?php echo esc_html(get_user_meta($u->ID, 'ofl_last_ai_chat', true)); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- extend chat agent manager with long term memory table and summarisation
- keep segmentation tags in prompts
- track user spend and last interaction in the chat plugin
- expose high value fans list in admin

## Testing
- `python3 -m py_compile chat-agent-manager/main.py`
- `php -l wp-content/plugins/onlyfans-like-chat/class-ai-chat-endpoints.php`
- `php -l wp-content/plugins/onlyfans-like-chat/onlyfans-like-chat.php`


------
https://chatgpt.com/codex/tasks/task_e_6881618841308326b223d59ddd95d08d