### PR TITLE
Add chat template and Vue component

### DIFF
--- a/wp-content/themes/astra-child/assets/css/chat.css
+++ b/wp-content/themes/astra-child/assets/css/chat.css
@@ -1,0 +1,9 @@
+.chat-container { max-width: 600px; margin: 0 auto; padding: 20px; }
+.chat-box { border: 1px solid #ddd; padding: 15px; }
+.chat-message { margin-bottom: 10px; padding: 8px 12px; border-radius: 4px; }
+.chat-message.me { background: #e1ffc7; text-align: right; }
+.chat-message.ai { background: #f1f1f1; }
+.typing { font-style: italic; margin-bottom: 10px; }
+.input-area { display: flex; gap: 5px; }
+.input-area input { flex: 1; padding: 6px; }
+.payment-prompt { background: #ffe0e0; padding: 10px; text-align: center; }

--- a/wp-content/themes/astra-child/assets/js/chat.js
+++ b/wp-content/themes/astra-child/assets/js/chat.js
@@ -1,0 +1,70 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const el = document.getElementById('chat-app');
+  if (!el || typeof Vue === 'undefined') return;
+
+  const { createApp } = Vue;
+
+  createApp({
+    data() {
+      return {
+        messages: [],
+        newMessage: '',
+        aiTyping: false
+      };
+    },
+    created() {
+      this.loadMessages();
+    },
+    methods: {
+      loadMessages() {
+        fetch('/wp-json/custom/v1/messages')
+          .then(r => r.json())
+          .then(d => { this.messages = Array.isArray(d) ? d : []; });
+      },
+      send() {
+        const text = this.newMessage.trim();
+        if (!text) return;
+        this.messages.push({ content: text, from: 'me' });
+        this.newMessage = '';
+        this.aiTyping = true;
+        fetch('/wp-json/custom/v1/message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text })
+        }).catch(() => {});
+        fetch('/wp-json/custom/v1/ai-chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text })
+        })
+          .then(r => r.json())
+          .then(res => {
+            if (res && res.type === 'exclusive_message' && res.link) {
+              this.messages.push({ content: res.link, from: 'ai', exclusive: true });
+            } else if (res && res.reply) {
+              this.messages.push({ content: res.reply, from: 'ai' });
+            }
+          })
+          .finally(() => {
+            this.aiTyping = false;
+          });
+      }
+    },
+    template: `
+      <div class="chat-box">
+        <div class="messages">
+          <div v-for="(m, i) in messages" :key="i" :class="['chat-message', m.from]">
+            <span v-if="!m.exclusive" v-html="m.content"></span>
+            <div v-else class="payment-prompt">
+              <a :href="m.content">Unlock Exclusive Message</a>
+            </div>
+          </div>
+          <div v-if="aiTyping" class="typing">AI is typing...</div>
+        </div>
+        <div class="input-area">
+          <input v-model="newMessage" @keyup.enter="send" placeholder="Type a message" />
+          <button @click="send">Send</button>
+        </div>
+      </div>`
+  }).mount('#chat-app');
+});

--- a/wp-content/themes/astra-child/functions.php
+++ b/wp-content/themes/astra-child/functions.php
@@ -880,3 +880,13 @@ function astra_child_creator_footer_link() {
 }
 add_action( 'astra_footer_content_bottom', 'astra_child_creator_footer_link' );
 
+
+// Enqueue chat assets when the Chat template is used
+function astra_child_enqueue_chat_assets() {
+    if (is_page_template('templates/page-chat.php')) {
+        wp_enqueue_style('astra-chat-style', get_stylesheet_directory_uri() . '/assets/css/chat.css', array(), CHILD_THEME_ASTRA_CHILD_VERSION);
+        wp_enqueue_script('vue', 'https://unpkg.com/vue@3/dist/vue.global.prod.js', array(), null, true);
+        wp_enqueue_script('astra-chat-js', get_stylesheet_directory_uri() . '/assets/js/chat.js', array('vue'), CHILD_THEME_ASTRA_CHILD_VERSION, true);
+    }
+}
+add_action('wp_enqueue_scripts', 'astra_child_enqueue_chat_assets');

--- a/wp-content/themes/astra-child/templates/page-chat.php
+++ b/wp-content/themes/astra-child/templates/page-chat.php
@@ -1,0 +1,9 @@
+<?php
+/*
+ * Template Name: Chat
+ * Description: AI Chat page.
+ */
+get_header();
+?>
+<div id="chat-app" class="chat-container"></div>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add new `page-chat.php` template for chat functionality
- implement a simple Vue chat component that fetches from REST endpoints
- include typing indicators and exclusive message payment prompt
- enqueue chat assets only on Chat template pages

## Testing
- `php -l wp-content/themes/astra-child/templates/page-chat.php`
- `php -l wp-content/themes/astra-child/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_688163b284f08326b45be687693ff896